### PR TITLE
Add support for files with metadata attached to individual postings.

### DIFF
--- a/beancount.sublime-syntax
+++ b/beancount.sublime-syntax
@@ -258,7 +258,7 @@ contexts:
       set:
         - meta_scope: meta.posting.beancount
         - match: '(?={{account}})'
-          push: [ optional_posting_leg_amount, account ]
+          push: [ metadata, optional_posting_leg_amount, account ]
         - match: '(?={{accountcomponent}})'
           comment: Partial account
           push: account
@@ -364,7 +364,6 @@ contexts:
       scope: punctuation.section.group.end.beancount
       set: [number_expr_continuation]
     - include: illegal
-
 
   currency:
     - match: '{{currency}}'


### PR DESCRIPTION
This feature is described in the beancount docs:
https://beancount.github.io/docs/beancount_language_syntax.html#metadata

It can also be verified that the grammar implementation allows specifying postings in any permutation:
https://github.com/beancount/beancount/blob/33f8ade1f9a2e2e7848d8597be852f10aaf3ef81/beancount/parser/grammar.y#L481

And that posting objects can have meta tags:
https://github.com/beancount/beancount/blob/33f8ade1f9a2e2e7848d8597be852f10aaf3ef81/beancount/core/data.py#L236

Indentation levels are not enforced as that's the existing behavior of this plugin.

Before:
<img width="227" height="113" alt="Screenshot" src="https://github.com/user-attachments/assets/3caf566a-4524-4f1f-b320-d7cd9f2ce6ef" />

After:
<img width="240" height="113" alt="Screenshot" src="https://github.com/user-attachments/assets/06b037d5-0420-4554-880c-f6d46451d656" />
